### PR TITLE
Added isUnblockInChatDisabled ApplozicSettings option

### DIFF
--- a/Applozic/Handlers/ALApplozicSettings.h
+++ b/Applozic/Handlers/ALApplozicSettings.h
@@ -88,6 +88,7 @@
 #define SWIFT_FRAMEWORK @"com.applozic.userfefault.SWIFT_FRAMEWORK"
 #define DEDICATED_SERVER @"com.applozic.userfefault.DEDICATED_SERVER"
 #define HIDE_ATTACHMENT_OPTION @"com.applozic.HIDE_ATTACHMENT_OPTIONS"
+#define DISABLE_UNBLOCK_FROM_CHAT @"com.applozic.DISABLE_UNBLOCK_FROM_CHAT"
 #define S3_STORAGE_SERVICE @"com.applozic.userdefault.S3_STORAGE_SERVICE"
 #define DEFAULT_GROUP_TYPE @"com.applozic.DEFAULT_GROUP_TYPE"
 #define CONTACTS_GROUP_ID_LIST @"com.applozic.userdefault.CONTACTS_GROUP_ID_LIST"
@@ -435,6 +436,11 @@ static NSString *const MEDIA_SELECT_OPTIONS = @"com.applozic.MEDIA_SELECT_OPTION
 +(BOOL) isSendVideoOptionHidden;
 +(BOOL) isLocationOptionHidden;
 +(BOOL) isBlockUserOptionHidden;
+
+// Enable/Disable unblock users from sendMessageTextView
++(void) setIsUnblockInChatDisabled:(BOOL)flag;
++(BOOL) isUnblockInChatDisabled;
+    
 +(BOOL) isShareContactOptionHidden;
 +(BOOL) isAttachmentButtonHidden;
 +(BOOL) isDocumentOptionHidden;

--- a/Applozic/Handlers/ALApplozicSettings.m
+++ b/Applozic/Handlers/ALApplozicSettings.m
@@ -1124,6 +1124,16 @@
     return ([[self getHideAttachmentsOption] containsObject:@":blockUser"]);
 }
 
++(void) setIsUnblockInChatDisabled:(BOOL)flag {
+    [[NSUserDefaults standardUserDefaults] setBool:flag forKey:DISABLE_UNBLOCK_FROM_CHAT];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
++(BOOL) isUnblockInChatDisabled {
+    BOOL key = [[NSUserDefaults standardUserDefaults] boolForKey:DISABLE_UNBLOCK_FROM_CHAT];
+    return key;
+}
+
 +(BOOL) isShareContactOptionHidden{
     return ([[self getHideAttachmentsOption] containsObject:@":shareContact"]);
 }

--- a/Applozic/ViewControllers/ALChatViewController.m
+++ b/Applozic/ViewControllers/ALChatViewController.m
@@ -930,7 +930,9 @@ NSString * const ThirdPartyDetailVCNotificationChannelKey = @"ThirdPartyDetailVC
                               }];
 
     [alert addAction:ok];
-    [alert addAction:unblock];
+    if (![ALApplozicSettings isUnblockInChatDisabled]) {
+        [alert addAction:unblock];
+    }
     [self presentViewController:alert animated:YES completion:nil];
 }
 


### PR DESCRIPTION
We added opportunity to avoid unblocking user from chat(in sendMessageTextView). It is very important option for us, because for now we don't have possibility handle this event outside your library for updating our database(users blocked list). For now this flow (unblocking user from chat) case initiate discrepancy between your internal database and our database. Please approve the PR or write to me on email: eugene.krupoderov@techs.com.ua

With the best wishes,
Eugene
Skylab team